### PR TITLE
Fixed install error for M1 mac

### DIFF
--- a/swarm-bee.rb
+++ b/swarm-bee.rb
@@ -8,7 +8,7 @@ class SwarmBee < Formula
   version "0.6.0"
   bottle :unneeded
 
-  if OS.mac? && Hardware::CPU.intel?
+  if OS.mac?
     url "https://github.com/ethersphere/bee/releases/download/v0.6.0/bee-darwin-amd64.tar.gz"
     sha256 "37f4e00c84b07dfffa73d2023cb11192b604959da48d1ecac83753564098ee1c"
   end


### PR DESCRIPTION
I fixed install error.
Because M1 Mac is not Hardware::CPU.intel, URL is null, I think so.

This changed , I succeeded install.

Thanks for very exciting application.

```
$ brew install swarm-bee
Error: formulae require at least a URL
/opt/homebrew/Library/Homebrew/formula.rb:272:in `determine_active_spec'
/opt/homebrew/Library/Homebrew/formula.rb:207:in `initialize'
/opt/homebrew/Library/Homebrew/formulary.rb:181:in `new'
/opt/homebrew/Library/Homebrew/formulary.rb:181:in `get_formula'
/opt/homebrew/Library/Homebrew/formulary.rb:404:in `factory'
/opt/homebrew/Library/Homebrew/cli/parser.rb:638:in `block in formulae'
/opt/homebrew/Library/Homebrew/cli/parser.rb:634:in `map'
/opt/homebrew/Library/Homebrew/cli/parser.rb:634:in `formulae'
/opt/homebrew/Library/Homebrew/cli/parser.rb:303:in `parse'
/opt/homebrew/Library/Homebrew/cmd/install.rb:131:in `install'
/opt/homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```